### PR TITLE
FEATURE: Add ignorePackages option for PrototypeNamePrefixRule

### DIFF
--- a/src/Rules/Neos/PrototypeNamePrefixRule.php
+++ b/src/Rules/Neos/PrototypeNamePrefixRule.php
@@ -39,6 +39,10 @@ class PrototypeNamePrefixRule extends FusionRule
             return;
         }
 
+        if (in_array($firstIdentifier->getValue(), $this->getOption('ignorePackages'), true)) {
+            return;
+        }
+
         $prototypeNameParts = explode('.', $prototypeName->getValue());
         if (!in_array(reset($prototypeNameParts), $this->getOption('validPrefixes'))) {
             $file->addError('Prototype name should start with: ' . implode(', ', $this->getOption('validPrefixes')), $firstIdentifier->getLine(), $firstIdentifier->getColumn(), $this->severity);

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -3,6 +3,7 @@ rules:
     class: 'Vette\Neos\CodeStyle\Rules\Neos\PrototypeNamePrefixRule'
     severity: warning
     options:
+      ignorePackages: ['Neos.Neos']
       validPrefixes: ['Content', 'Document', 'Component', 'Helper', 'Presentation', 'Integration']
   onlyIncludesInRootFile:
     class: 'Vette\Neos\CodeStyle\Rules\Neos\OnlyIncludesInRootRule'


### PR DESCRIPTION
When you override Prototypes from "Neos.Neos" the PrototypeNamePrefixRule will always warn that you don't follow the rule. Therefore it would be nice to exclude packages like "Neos.Neos" from that rule.