### PR TITLE
TASK: Add Neos.Fusion to the ignored packages

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -3,7 +3,7 @@ rules:
     class: 'Vette\Neos\CodeStyle\Rules\Neos\PrototypeNamePrefixRule'
     severity: warning
     options:
-      ignorePackages: ['Neos.Neos']
+      ignorePackages: ['Neos.Neos', 'Neos.Fusion']
       validPrefixes: ['Content', 'Document', 'Component', 'Helper', 'Presentation', 'Integration']
   onlyIncludesInRootFile:
     class: 'Vette\Neos\CodeStyle\Rules\Neos\OnlyIncludesInRootRule'


### PR DESCRIPTION
Adds `Neos.Fusion` to the ignored packages for the PrototypeNamePrefixRule.
When you override prototypes from Fusion, this will also lead to unwanted warnings.

For instance, if you adjust the `Neos.Fusion:GlobalCacheIdentifiers`