### PR TITLE
BUGFIX: Custom rules and files dont work

### DIFF
--- a/src/CodeStyle.php
+++ b/src/CodeStyle.php
@@ -62,11 +62,11 @@ class CodeStyle
             $this->config['defaultReport'] = $parameters->getReport();
         }
 
-        if ($parameters->getIncludes() !== null) {
+        if (!empty($parameters->getIncludes())) {
             $this->config['includes'] = $parameters->getIncludes();
         }
 
-        if ($parameters->getFiles() !== null) {
+        if (!empty($parameters->getFiles())) {
             $this->config['files'] = $parameters->getFiles();
         }
 


### PR DESCRIPTION
This fixes a regression in 7ca0f14e271ac39a408c688f36feb498cf9f1346 as files and includes are empty arrays but never null.

This overwrote any config from the yaml file therefore.